### PR TITLE
Added pre-requisite line on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,11 @@ colcon build
 Follow the instructions of [rmf_core](https://github.com/osrf/rmf_core#Installation) and
 [traffic_editor](https://github.com/osrf/traffic_editor#Installation) to build and install them.
 
-Build and install with npm
+Install and build with npm
 ```
 npm install
+
+npm build
 ```
+
+Obs: installing [jinja2](https://pypi.org/project/Jinja2/) with python is pre-requisite to build.


### PR DESCRIPTION
I did a fresh OS reinstall, which removed all my python packages.
After installing and building rmf_demos with all its python dependencies, when I tried to install this project, it asked me for an extra dependency, which is Jinja. So I'm adding this to the Readme.

HTH.